### PR TITLE
Add workflow to rebuild dist/ on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-rebuild-dist.yml
+++ b/.github/workflows/dependabot-rebuild-dist.yml
@@ -1,0 +1,60 @@
+# Dependabot only updates package.json/package-lock.json but doesn't rebuild
+# the checked-in dist/ directory. This workflow detects Dependabot PRs,
+# rebuilds dist/, and pushes the result back to the PR branch so that the
+# "Check Transpiled JavaScript" workflow passes.
+#
+# Uses a GitHub App token so the push triggers subsequent workflow runs.
+name: Rebuild dist/ for Dependabot PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  rebuild-dist:
+    name: Rebuild dist/
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.KITOPS_BOT_ID }}
+          private-key: ${{ secrets.KITOPS_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build dist/ Directory
+        run: npm run bundle
+
+      - name: Push updated dist/
+        run: |
+          if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add dist/
+            git commit -m "Rebuild dist/ for Dependabot update"
+            git push
+          else
+            echo "dist/ is already up to date"
+          fi


### PR DESCRIPTION
## What changed
Adds a new GitHub Actions workflow (`dependabot-rebuild-dist.yml`) that automatically rebuilds the checked-in `dist/` directory when Dependabot opens a PR.

## Why
Dependabot updates `package.json`/`package-lock.json` but doesn't run `npm run bundle`, so the `check-dist` CI job always fails on Dependabot PRs. This workflow detects Dependabot PRs, rebuilds `dist/`, and pushes the result back to the PR branch.

Uses the existing KitOps bot GitHub App token so the push triggers subsequent CI workflow runs.

## Validation
- Reviewed workflow YAML for correctness
- Verified action pin SHAs match those used in existing workflows (`check-dist.yml`)
- Scoped to `github.actor == 'dependabot[bot]'` only — no effect on human PRs